### PR TITLE
Document the usage of fixture helpers and addCleanup. Don't use setUp and teardown

### DIFF
--- a/docs/programming/testing.rst
+++ b/docs/programming/testing.rst
@@ -689,6 +689,12 @@ With code in setUp, the helper code will always be executed and is much harder
 to detect and we are left with objects created in setUp but not used in any
 other test.
 
+As a code smell, is not of to use setUp and tearDown for classed which have
+test methods.
+Is OK to use setUp/tearDown for high level test cases which don't have
+any self test method and are designed to be reused by more than 2 other
+final test cases.
+
 In the same time, objects created in setUp will create a stronger dependency
 between the tests using that object.
 Changing the way an object is created in setUp in order to please a test might

--- a/docs/programming/testing.rst
+++ b/docs/programming/testing.rst
@@ -586,9 +586,9 @@ put it in a dedicated, reusable, method.
 
 
 The *arrange* part might create multiple fixtures and initialize multiple
-object.
+objects.
 To make the code easier to read and to make it easier to identify which object
-is targeted by the test name the system under test object as `sut`.
+is targeted by the test, name the system under test object as `sut`.
 
 
 .. sourcecode:: python


### PR DESCRIPTION
Scope
=====

This updates the testing documentation to discourage the usage of setUp  tearDown in favor or fixture helpers and addCleanup


Why we got into this (5 whys)
=============================

I don't know why this was not updated. In the reference there was a link to a page describing this issue.


Changes
=======

This tries to add some example and argument why setUp / tearDown are bad.

How to try and test the changes
===============================

reviewers: @bgola @stas 

Please check that changes make sense.

Please suggest any changes / improvements.

Thanks!